### PR TITLE
Deprecate New Relic Browser Plugin

### DIFF
--- a/NewRelicBrowser.php
+++ b/NewRelicBrowser.php
@@ -363,7 +363,11 @@ if ( ! class_exists( 'Rt_Newrelic' ) ) {
 							$create_browser_response_code = wp_remote_retrieve_response_code( $create_browser_response );
 							$json_data = json_decode( $create_browser_response['body'] );
 							if ( 201 != $create_browser_response_code ) {
-								add_settings_error( 'relic_options', 'relic_options_error', $json_data->error, 'error' );
+								if (isset($json_data->error)) {
+									add_settings_error('relic_options', 'relic_options_error', $json_data->error, 'error');
+								} else {
+									add_settings_error('relic_options', 'relic_options_error', 'Something went wrong', 'error');
+								}
 							} else if ( isset( $json_data->api_key ) ) {
 								/* store the received data */
 								$main_array = array(

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 # New Relic Browser by rtCamp #
 
-* **Contributors:** [rtcamp] (http://profiles.wordpress.org/rtcamp), [newrelic] (http://profiles.wordpress.org/newrelic), [prasad-nevase] (http://profiles.wordpress.org/prasad-nevase), [rakshit] (http://profiles.wordpress.org/rakshit), [rohanveer] (http://profiles.wordpress.org/rohanveer), [brennenlb] (http://profiles.wordpress.org/brennenlb)
+* **Contributors:** [rtcamp] (http://profiles.wordpress.org/rtcamp), [newrelic] (http://profiles.wordpress.org/newrelic), [prasad-nevase] (http://profiles.wordpress.org/prasad-nevase), [rakshit] (http://profiles.wordpress.org/rakshit), [rohanveer] (http://profiles.wordpress.org/rohanveer), [brennenlb] (http://profiles.wordpress.org/brennenlb), [snehapatil02] (https://profiles.wordpress.org/snehapatil02/)
 
 * **License:** [GPL v2 or later] ( http://opensource.org/licenses/mit-license.html)
 

--- a/readme.md
+++ b/readme.md
@@ -2,69 +2,53 @@
 
 # New Relic Browser by rtCamp #
 
-* **Contributors:** [rtcamp] (http://profiles.wordpress.org/rtcamp), [newrelic] (http://profiles.wordpress.org/newrelic), [prasad-nevase] (http://profiles.wordpress.org/prasad-nevase), [rakshit] (http://profiles.wordpress.org/rakshit), [rohanveer] (http://profiles.wordpress.org/rohanveer), [brennenlb] (http://profiles.wordpress.org/brennenlb), [snehapatil02] (https://profiles.wordpress.org/snehapatil02/)
+> **⚠️ This plugin will be retired soon.**  
+> New Relic PHP Agent now handles PHP Agent Integration Performance tracking directly on the server. The New Relic PHP Agent captures and reports key metrics automatically to the New Relic APM dashboard, eliminating the need for this plugin.
 
-* **License:** [GPL v2 or later] ( http://opensource.org/licenses/mit-license.html)
+---
 
-* **Donate Link:**  http://rtcamp.com/donate
+* **Contributors:** [rtcamp] (http://profiles.wordpress.org/rtcamp), [newrelic](http://profiles.wordpress.org/newrelic), [prasad-nevase](http://profiles.wordpress.org/prasad-nevase), [rakshit](http://profiles.wordpress.org/rakshit), [rohanveer](http://profiles.wordpress.org/rohanveer), [brennenlb](http://profiles.wordpress.org/brennenlb), [snehapatil02](https://profiles.wordpress.org/snehapatil02/)
+
+* **License:** [GPL v2 or later](http://opensource.org/licenses/mit-license.html)
+
+* **Donate Link:**  [rtCamp Donate](http://rtcamp.com/donate)
 
 This plugin instantly adds free New Relic Browser monitoring to your website.
 
-## Description ##
+## Description
 
-[New Relic Browser](http://newrelic.com/browser-monitoring) provides deep visibility and actionable insights into real users experiences on your website.
-With standard page load timing (sometimes referred to as real user monitoring or RUM), New Relic measures the overall time to load the entire webpage.
-However, New Relic Browser goes beyond RUM to also help you monitor the performance of individual sessions, AJAX requests, and javascript errorsÃ¢â‚¬â€extending the monitoring throughout the entire life cycle of the page.
+[New Relic Browser](http://newrelic.com/browser-monitoring) provides deep visibility and actionable insights into real users' experiences on your website.
+
+### **New Notice:**
+With the New Relic PHP Agent's updated functionality, monitoring is now automatic, requiring no custom plugin. We encourage users to switch to server-level integration for better performance and efficiency.
+
+#### Previous Details (For Reference)
 
 This plugin instantly adds New Relic’s Browser monitoring javascript to your WordPress site. If you do not have a New Relic account, this plugin allows you to instantly create one. If you already have a New Relic account, you’ll be prompted for your New Relic API key to connect your Browser monitoring with your account. Either way, when you complete the super-simple configuration, the latest New Relic Browser monitoring javascript will be loaded automatically in `<head></head>` tag of your site without any manual effort.
 
 New Relic Browser Lite is free for unlimited pageviews. Every new New Relic account includes a two-week free trial of Browser Pro, which offers [many more features](http://newrelic.com/browser-monitoring/pricing) - usage of Browser Pro beyond the trial period is a [paid upgrade](http://newrelic.com/browser-monitoring/pricing). If you don’t upgrade, your account will automatically revert to Browser Lite, for free, forever!
 
-#### Features ####
+### Frequently Asked Questions
 
-* Allows you to create a New Relic Account and Browser App instantly.
-* If you already have New Relic Account, you can select between creating a new Browser app, or connecting your website to an existing browser app.
-* You do not need to edit your theme's header file manually to insert the New Relic Browser javascript, nor do you need to worry about updating the javascript when New Relic releases new versions - this plugin takes care of all that!
-* Compatible with WordPress Multisite.
-* Thoroughly tested on the top 10-WordPress open source themes and plugins in WordPress themes/plugins repository.
-* Actively supported by rtCamp and New Relic.
+### Q: What’s changing with this plugin? ###  
+A: This plugin is being retired because the New Relic PHP Agent now automatically captures and reports performance metrics directly.
 
-**Important Links**
+### Q: How do I continue to use New Relic Browser monitoring? ###  
+A: Configure the New Relic PHP Agent on your server following New Relic's official [documentation](https://docs.newrelic.com).
 
-* [GitHub](http://github.com/rtcamp/rt-newrelic-browser) - Please mention your wordpress.org username when sending pull requests.
+### Q: Why is this plugin being retired? ###
+A: The New Relic PHP Agent now includes built-in support for browser monitoring, eliminating the need for a separate WordPress plugin. This ensures more efficient and reliable performance tracking at the server level.
 
-## Installation ##
+### Q: How can I continue to use New Relic Browser monitoring? ###
+A: To continue using New Relic Browser monitoring:
+1. Configure the New Relic PHP Agent on your server.
+2. Follow the official [New Relic Browser monitoring setup guide](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring/).
 
-* Install the plugin from the 'Plugins' section in your dashboard (Go to `Plugins > Add New > Search` and search for 'New Relic Browser by rtCamp').
-* Alternatively, you can [download](http://downloads.wordpress.org/plugin/rt-newrelic-browser.zip "Download New Relic Browser by rtCamp") the plugin from the repository. Unzip it and upload it to the plugins folder of your WordPress installation (`wp-content/plugins/` directory of your WordPress installation).
-* Activate it through the 'Plugins' section.
-* Access the settings page from WordPress backend under `Settings > New Relic Browser`.
-* Once the plugin is configured, wait a minute or two, then login to your New Relic account to see Browser monitoring details.
+### Q: What happens if I keep using this plugin? ###
+A: The plugin will no longer receive updates or support. While it may still function temporarily, future changes to WordPress or New Relic may cause compatibility issues.
 
-## Frequently Asked Questions ##
-
-#### What if I do not have New Relic account? ####
-This plugin will create one for you.
-
-#### If I have a New Relic account, where do I find my API Key? ####
-[Here](https://docs.newrelic.com/docs/apm/apis/requirements/api-key#creating)! Make sure to use your 'API Key' and not your ’Data access key'.
-
-#### What if I accidentally disable the plugin and thus disable New Relic Browser monitoring? ####
-No worries - simply re-enable the plugin, indicate you have an existing New Relic account, and provide [your API Key](https://docs.newrelic.com/docs/apm/apis/requirements/api-key#creating).
-
-#### Something is not working - what do I do? ####
-Sorry about that! Please open a [Github Issue](https://github.com/rtCamp/rt-newrelic-browser/issues) or post to this plugin’s [Support section](https://wordpress.org/support/plugin/rt-newrelic-browser).
-
-#### Do I have to pay to use New Relic? ####
-Nope! New Relic’s services, including [Browser monitoring](http://newrelic.com/browser-monitoring), [APM for your WordPress PHP app](http://newrelic.com/php/wordpress) (and [many other languages](http://newrelic.com/application-monitoring)), [Server monitoring](http://newrelic.com/server-monitoring), [Synthetic monitoring](http://newrelic.com/synthetics), and even [Plugins for your entire stack](http://newrelic.com/platform/), are all available in ‘Lite’ versions for free forever!
-
-
-## Screenshots ##
-
-1. Select whether or not you have a New Relic account.
-2. If you have a New Relic account, then select an existing Browser Application, or create a new one.
-3. Enter required details to create a New Relic account.
-4. You’ll see this when you are done!
+### Q: Where can I find help for configuring the New Relic PHP Agent? ###
+A: You can refer to the official [New Relic PHP Agent documentation](https://docs.newrelic.com/docs/agents/php-agent/) or contact New Relic support for assistance.
 
 ## Changelog ##
 
@@ -88,6 +72,7 @@ Nope! New Relic’s services, including [Browser monitoring](http://newrelic.com
 #### 1.0.5 ####
 * Updated API Key Location in description.
 
-## Does this interest you?
+#### 1.0.6  
+* **New:** Deprecation notice added.
 
 <a href="https://rtcamp.com/"><img src="https://rtcamp.com/wp-content/uploads/2019/04/github-banner@2x.png" alt="Join us at rtCamp, we specialize in providing high performance enterprise WordPress solutions"></a>

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === New Relic Browser by rtCamp ===
-Contributors: rtcamp,newrelic,prasad-nevase,rakshit,rohanveer,brennenlb
+Contributors: rtcamp,newrelic,prasad-nevase,rakshit,rohanveer,brennenlb,snehapatil02
 Donate Link:  http://rtcamp.com/donate
 Tags: new relic browser for wordpress, new relic wordpress, new relic wordpress analytics, new relic wordpress multisite, new relic wordpress mu, javascript monitoring, javascript errors, browser monitoring
 Requires at least: 3.0.1

--- a/readme.txt
+++ b/readme.txt
@@ -10,24 +10,19 @@ License URI: http://opensource.org/licenses/mit-license.html
 
 This plugin instantly adds free New Relic Browser monitoring to your website.
 
+⚠️ **This plugin will be retired soon.**  
+The New Relic PHP Agent now manages all functionalities without requiring this plugin. For continued performance tracking, configure the New Relic PHP Agent.
+
 == Description ==
 
-[New Relic Browser](http://newrelic.com/browser-monitoring) provides deep visibility and actionable insights into real users experiences on your website.
-With standard page load timing (sometimes referred to as real user monitoring or RUM), New Relic measures the overall time to load the entire webpage.
-However, New Relic Browser goes beyond RUM to also help you monitor the performance of individual sessions, AJAX requests, and javascript errors extending the monitoring throughout the entire life cycle of the page.
+**New Notice:**  
+The New Relic PHP Agent eliminates the need for this plugin by capturing and reporting key metrics directly to the APM dashboard.
+
+= Previous Details (For Reference) =
 
 This plugin instantly adds New Relic’s Browser monitoring javascript to your WordPress site. If you do not have a New Relic account, this plugin allows you to instantly create one. If you already have a New Relic account, you’ll be prompted for your New Relic API key to connect your Browser monitoring with your account. Either way, when you complete the super-simple configuration, the latest New Relic Browser monitoring javascript will be loaded automatically in `<head></head>` tag of your site without any manual effort.
 
 New Relic Browser Lite is free for unlimited pageviews. Every new New Relic account includes a two-week free trial of Browser Pro, which offers [many more features](http://newrelic.com/browser-monitoring/pricing) - usage of Browser Pro beyond the trial period is a [paid upgrade](http://newrelic.com/browser-monitoring/pricing). If you don’t upgrade, your account will automatically revert to Browser Lite, for free, forever!
-
-= Features =
-
-* Allows you to create a New Relic Account and Browser App instantly.
-* If you already have New Relic Account, you can select between creating a new Browser app, or connecting your website to an existing browser app.
-* You do not need to edit your theme's header file manually to insert the New Relic Browser javascript, nor do you need to worry about updating the javascript when New Relic releases new versions - this plugin takes care of all that!
-* Compatible with WordPress Multisite.
-* Thoroughly tested on the top 10-WordPress open source themes and plugins in WordPress themes/plugins repository.
-* Actively supported by rtCamp and New Relic.
 
 **Important Links**
 
@@ -43,21 +38,25 @@ New Relic Browser Lite is free for unlimited pageviews. Every new New Relic acco
 
 == Frequently Asked Questions ==
 
-= What if I do not have New Relic account? =
-This plugin will create one for you.
+= What’s changing with this plugin? =
+This plugin is being retired because the New Relic PHP Agent now automatically captures and reports performance metrics directly.
 
-= If I have a New Relic account, where do I find my API Key? =
-[Here](https://docs.newrelic.com/docs/apm/apis/requirements/api-key#creating)! Make sure to use your 'API Key' and not your ’Data access key'.
+= How do I continue to use New Relic Browser monitoring? =  
+Configure the New Relic PHP Agent on your server following New Relic's official [documentation](https://docs.newrelic.com).
 
-= What if I accidentally disable the plugin and thus disable New Relic Browser monitoring? =
-No worries - simply re-enable the plugin, indicate you have an existing New Relic account, and provide [your API Key](https://docs.newrelic.com/docs/apm/apis/requirements/api-key#creating).
+= Why is this plugin being retired? =
+The New Relic PHP Agent now includes built-in support for browser monitoring, eliminating the need for a separate WordPress plugin. This ensures more efficient and reliable performance tracking at the server level.
 
-= Something is not working - what do I do? =
-Sorry about that! Please open a [Github Issue](https://github.com/rtCamp/rt-newrelic-browser/issues) or post to this plugin’s [Support section](https://wordpress.org/support/plugin/rt-newrelic-browser).
+= How can I continue to use New Relic Browser monitoring? =
+To continue using New Relic Browser monitoring:
+1. Configure the New Relic PHP Agent on your server.
+2. Follow the official [New Relic Browser monitoring setup guide](https://docs.newrelic.com/docs/browser/new-relic-browser/getting-started/introduction-browser-monitoring/).
 
-= Do I have to pay to use New Relic? =
-Nope! New Relic’s services, including [Browser monitoring](http://newrelic.com/browser-monitoring), [APM for your WordPress PHP app](http://newrelic.com/php/wordpress) (and [many other languages](http://newrelic.com/application-monitoring)), [Server monitoring](http://newrelic.com/server-monitoring), [Synthetic monitoring](http://newrelic.com/synthetics), and even [Plugins for your entire stack](http://newrelic.com/platform/), are all available in ‘Lite’ versions for free forever!
+= What happens if I keep using this plugin? =
+The plugin will no longer receive updates or support. While it may still function temporarily, future changes to WordPress or New Relic may cause compatibility issues.
 
+= Where can I find help for configuring the New Relic PHP Agent? =
+You can refer to the official [New Relic PHP Agent documentation](https://docs.newrelic.com/docs/agents/php-agent/) or contact New Relic support for assistance.
 
 == Screenshots ==
 
@@ -87,3 +86,6 @@ Nope! New Relic’s services, including [Browser monitoring](http://newrelic.com
 
 = 1.0.5 =
 * Updated API Key Location in description.
+
+= 1.0.6 =
+* Deprecation notice added.


### PR DESCRIPTION
This PR updates the readme.md and readme.txt files to reflect the upcoming deprecation of the rtNewRelic Browser plugin. The New Relic PHP Agent now handles browser performance monitoring directly on the server side, eliminating the need for this plugin.

Changes:

- Proper error handling.
- Added a deprecation notice to both readme.md and readme.txt, informing users of the plugin's retirement.
- Updated the description to encourage users to configure the New Relic PHP Agent directly on the server for continued performance monitoring.